### PR TITLE
Fix strptime pattern

### DIFF
--- a/crimemap/apps/map/management/commands/import1.py
+++ b/crimemap/apps/map/management/commands/import1.py
@@ -29,10 +29,10 @@ class Command(BaseCommand):
 				)
 
 			date_reported_object = strptime(h[1].strip(), '%m/%d/%Y')
-			time_reported_object = strptime(h[2].strip(), '%H:%M:00 %p')
+			time_reported_object = strptime(h[2].strip(), '%I:%M:00 %p')
 			date_occurred_object = strptime(h[3].strip(), '%m/%d/%Y')
 			if len(h[4].strip()) > 0:
-				time_occurred_object = strptime(h[4].strip(), '%H:%M:00 %p')
+				time_occurred_object = strptime(h[4].strip(), '%I:%M:00 %p')
 			else:
 				time_occurred = strptime('', '')
 

--- a/crimemap/apps/map/management/commands/import2.py
+++ b/crimemap/apps/map/management/commands/import2.py
@@ -29,10 +29,10 @@ class Command(BaseCommand):
 				)
 
 			date_reported_object = strptime(h[1].strip(), '%m/%d/%Y')
-			time_reported_object = strptime(h[2].strip(), '%H:%M:00 %p')
+			time_reported_object = strptime(h[2].strip(), '%I:%M:00 %p')
 			date_occurred_object = strptime(h[3].strip(), '%m/%d/%Y')
 			if len(h[4].strip()) > 0:
-				time_occurred_object = strptime(h[4].strip(), '%H:%M:00 %p')
+				time_occurred_object = strptime(h[4].strip(), '%I:%M:00 %p')
 			else:
 				time_occurred = strptime('', '')
 


### PR DESCRIPTION
Hi, I found your project by searching for "strptime," "%H," and "%p" on GitHub. Changing %H to %I as detailed in this pull request will fix time parsing, as using "%H" with 12-hour times will ignore AM/PM and always give you the AM equivalent, even when %p is in the format string. I was bit by the same issue earlier today. Hope this helps!
